### PR TITLE
feat: allow unused spread

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     // Override @typescript-eslint/recommended
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
     '@typescript-eslint/restrict-template-expressions': [
       'error',
       {


### PR DESCRIPTION
```ts
const {prop, ...fooWithoutProp} = foo
```

currently produces a yellow/warning.  I'd like to 
1. make this warning go away
2. encourage spread-dropping of props into a new const over deleting props off an existing object.