### PR TITLE
Sm/allow delete via rest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,29 +3,33 @@ module.exports = {
     es6: true,
   },
   extends: [
-    'eslint-config-salesforce',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'eslint-config-prettier',
+    "eslint-config-salesforce",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "eslint-config-prettier",
   ],
-  parser: '@typescript-eslint/parser',
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     project: [
-      './packages/**/tsconfig.json',
-      './packages/**/test/tsconfig.json',
-      './tsconfig.json',
-      './test/tsconfig.json',
+      "./packages/**/tsconfig.json",
+      "./packages/**/test/tsconfig.json",
+      "./tsconfig.json",
+      "./test/tsconfig.json",
     ],
-    sourceType: 'module',
+    sourceType: "module",
   },
-  plugins: ['@typescript-eslint', 'eslint-plugin-import', 'eslint-plugin-jsdoc'],
+  plugins: [
+    "@typescript-eslint",
+    "eslint-plugin-import",
+    "eslint-plugin-jsdoc",
+  ],
   rules: {
     // Override @typescript-eslint/recommended
-    '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-namespace': 'off',
-    '@typescript-eslint/restrict-template-expressions': [
-      'error',
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
       {
         allowNullish: true,
         allowBoolean: true,
@@ -34,56 +38,62 @@ module.exports = {
     ],
 
     // Custom @typescript-eslint
-    '@typescript-eslint/array-type': [
-      'error',
+    "@typescript-eslint/array-type": [
+      "error",
       {
-        default: 'array-simple',
+        default: "array-simple",
       },
     ],
-    '@typescript-eslint/consistent-type-assertions': 'error',
-    '@typescript-eslint/explicit-function-return-type': 'error',
-    '@typescript-eslint/explicit-member-accessibility': [
-      'error',
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
       {
-        accessibility: 'explicit',
+        accessibility: "explicit",
       },
     ],
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
       {
         multiline: {
-          delimiter: 'semi',
+          delimiter: "semi",
           requireLast: true,
         },
         singleline: {
-          delimiter: 'semi',
+          delimiter: "semi",
           requireLast: false,
         },
       },
     ],
-    '@typescript-eslint/member-ordering': 'error',
+    "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-shadow": "error",
-    '@typescript-eslint/return-await': 'error',
+    "@typescript-eslint/return-await": "error",
     // turning off the base rule is recommended by ts-eslint
-    'no-return-await': 'off',
-    '@typescript-eslint/prefer-for-of': 'error',
-    '@typescript-eslint/prefer-function-type': 'error',
-    '@typescript-eslint/prefer-includes': 'error',
-    '@typescript-eslint/prefer-nullish-coalescing': 'error',
-    '@typescript-eslint/prefer-optional-chain': 'error',
-    '@typescript-eslint/prefer-reduce-type-parameter': 'error',
-    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-    '@typescript-eslint/quotes': [
-      'error',
-      'single',
+    "no-return-await": "off",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
       {
         avoidEscape: true,
       },
     ],
-    '@typescript-eslint/switch-exhaustiveness-check': 'error',
-    '@typescript-eslint/type-annotation-spacing': 'error',
-    '@typescript-eslint/unified-signatures': 'error',
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "@typescript-eslint/type-annotation-spacing": "error",
+    "@typescript-eslint/unified-signatures": "error",
+    // allow deleting object properties via rest operator
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { ignoreRestSiblings: true },
+    ],
+
     "no-shadow": "off",
   },
-  ignorePatterns: ['*.js'],
+  ignorePatterns: ["*.js"],
 };

--- a/.github/workflows/externalLint.yml
+++ b/.github/workflows/externalLint.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      packageName:
+        description: 'The npm package that this repository publishes.  ex: @salesforce/core'
+        required: true
+        type: string
+      externalProjectGitUrl:
+        description: 'The url that will be cloned.  This contains the NUTs you want to run.  Ex: https://github.com/salesforcecli/plugin-user'
+        type: string
+        required: true
+      command:
+        required: false
+        type: string
+        default: yarn eslint "src/**/*.ts"
+        description: 'command to execute (ex: yarn lint)'
+      preBuildCommands:
+        required: false
+        description: 'commands to run before the build...for example, to delete known module conflicts'
+        type: string
+        default: 'echo "no preBuildCommands passed"'
+      postBuildCommands:
+        required: false
+        description: 'script to run after the build'
+        type: string
+        default: 'echo "no postBuildCommands passed"'
+      preExternalBuildCommands:
+        required: false
+        description: 'commands to run before the build of the external repo...for example, to delete known module conflicts'
+        type: string
+        default: 'echo "no preExternalBuildCommands passed"'
+
+jobs:
+  external-lint:
+    name: ${{ inputs.command }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+      - run: git clone ${{ inputs.externalProjectGitUrl}} $(pwd)
+      - run: yarn install  --network-timeout 600000
+      - name: swap this dependency for the version on this branch
+        run: |
+          yarn remove ${{ inputs.packageName }}
+          yarn add ${{ github.repository }}#${{ github.sha }} --dev
+      - name: install/build ${{ inputs.packageName}} in node_modules
+        working-directory: node_modules/${{ inputs.packageName }}
+        run: |
+          yarn install  --network-timeout 600000
+          ${{ inputs.preBuildCommands }}
+          yarn build
+          ${{ inputs.postBuildCommands }}
+      - name: preExternalBuildCommands
+        run: ${{ inputs.preExternalBuildCommands }}
+      - name: lint
+        run: ${{ inputs.command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,25 +15,28 @@ jobs:
       fail-fast: false
       matrix:
         externalProjectGitUrl:
-          # - https://github.com/salesforcecli/plugin-auth
-          # - https://github.com/salesforcecli/plugin-apex
-          # - https://github.com/salesforcecli/plugin-community
-          # - https://github.com/salesforcecli/plugin-custom-metadata
-          # - https://github.com/salesforcecli/plugin-data
-          # - https://github.com/salesforcecli/plugin-deploy-retrieve
-          # - https://github.com/salesforcecli/plugin-dev
-          # - https://github.com/salesforcecli/plugin-env
-          # - https://github.com/salesforcecli/plugin-info
-          # - https://github.com/salesforcecli/plugin-limits
-          # - https://github.com/salesforcecli/plugin-login
-          # - https://github.com/salesforcecli/plugin-org
-          # - https://github.com/salesforcecli/plugin-packaging
-          # - https://github.com/salesforcecli/plugin-schema
-          # - https://github.com/salesforcecli/plugin-settings
-          # - https://github.com/salesforcecli/plugin-signups
-          # - https://github.com/salesforcecli/plugin-sobject
-          # - https://github.com/salesforcecli/plugin-templates
+          - https://github.com/salesforcecli/plugin-auth
+          - https://github.com/salesforcecli/plugin-apex
+          - https://github.com/salesforcecli/plugin-community
+          - https://github.com/salesforcecli/plugin-custom-metadata
+          - https://github.com/salesforcecli/plugin-data
+          - https://github.com/salesforcecli/plugin-deploy-retrieve
+          - https://github.com/salesforcecli/plugin-dev
+          - https://github.com/salesforcecli/plugin-env
+          - https://github.com/salesforcecli/plugin-info
+          - https://github.com/salesforcecli/plugin-limits
+          - https://github.com/salesforcecli/plugin-login
+          - https://github.com/salesforcecli/plugin-org
+          - https://github.com/salesforcecli/plugin-packaging
+          - https://github.com/salesforcecli/plugin-schema
+          - https://github.com/salesforcecli/plugin-settings
+          - https://github.com/salesforcecli/plugin-signups
+          - https://github.com/salesforcecli/plugin-sobject
+          - https://github.com/salesforcecli/plugin-templates
           - https://github.com/salesforcecli/plugin-user
+          - https://github.com/forcedotcom/source-deploy-retrieve
+          - https://github.com/forcedotcom/source-tracking
+          - https://github.com/forcedotcom/sfdx-core
 
     with:
       packageName: "eslint-config-salesforce-typescript"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,34 +8,34 @@ jobs:
   yarn-lockfile-check:
     uses: salesforcecli/github-workflows/.github/workflows/lockFileCheck.yml@main
 
-  lint-external:
-    uses: ./.github/workflows/externalLint.yml
-    needs: [yarn-lockfile-check]
-    strategy:
-      fail-fast: false
-      matrix:
-        externalProjectGitUrl:
-          # - https://github.com/salesforcecli/plugin-auth
-          # - https://github.com/salesforcecli/plugin-apex
-          # - https://github.com/salesforcecli/plugin-community
-          # - https://github.com/salesforcecli/plugin-custom-metadata
-          # - https://github.com/salesforcecli/plugin-data
-          # - https://github.com/salesforcecli/plugin-deploy-retrieve
-          # - https://github.com/salesforcecli/plugin-dev
-          # - https://github.com/salesforcecli/plugin-env
-          # - https://github.com/salesforcecli/plugin-info
-          # - https://github.com/salesforcecli/plugin-limits
-          # - https://github.com/salesforcecli/plugin-login
-          # - https://github.com/salesforcecli/plugin-org
-          # - https://github.com/salesforcecli/plugin-packaging
-          # - https://github.com/salesforcecli/plugin-schema
-          # - https://github.com/salesforcecli/plugin-settings
-          # - https://github.com/salesforcecli/plugin-signups
-          # - https://github.com/salesforcecli/plugin-sobject
-          # - https://github.com/salesforcecli/plugin-templates
-          - https://github.com/salesforcecli/plugin-user
+  # lint-external:
+  #   uses: ./.github/workflows/externalLint.yml
+  #   needs: [yarn-lockfile-check]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       externalProjectGitUrl:
+  #         # - https://github.com/salesforcecli/plugin-auth
+  #         # - https://github.com/salesforcecli/plugin-apex
+  #         # - https://github.com/salesforcecli/plugin-community
+  #         # - https://github.com/salesforcecli/plugin-custom-metadata
+  #         # - https://github.com/salesforcecli/plugin-data
+  #         # - https://github.com/salesforcecli/plugin-deploy-retrieve
+  #         # - https://github.com/salesforcecli/plugin-dev
+  #         # - https://github.com/salesforcecli/plugin-env
+  #         # - https://github.com/salesforcecli/plugin-info
+  #         # - https://github.com/salesforcecli/plugin-limits
+  #         # - https://github.com/salesforcecli/plugin-login
+  #         # - https://github.com/salesforcecli/plugin-org
+  #         # - https://github.com/salesforcecli/plugin-packaging
+  #         # - https://github.com/salesforcecli/plugin-schema
+  #         # - https://github.com/salesforcecli/plugin-settings
+  #         # - https://github.com/salesforcecli/plugin-signups
+  #         # - https://github.com/salesforcecli/plugin-sobject
+  #         # - https://github.com/salesforcecli/plugin-templates
+  #         - https://github.com/salesforcecli/plugin-user
 
-    with:
-      packageName: "eslint-config-salesforce-typescript"
-      externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
-      # preBuildCommands: yarn remove @types/jest
+  #   with:
+  #     packageName: "eslint-config-salesforce-typescript"
+  #     externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
+  #     # preBuildCommands: yarn remove @types/jest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,34 +8,34 @@ jobs:
   yarn-lockfile-check:
     uses: salesforcecli/github-workflows/.github/workflows/lockFileCheck.yml@main
 
-  # lint-external:
-  #   uses: ./.github/workflows/externalLint.yml
-  #   needs: [yarn-lockfile-check]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       externalProjectGitUrl:
-  #         # - https://github.com/salesforcecli/plugin-auth
-  #         # - https://github.com/salesforcecli/plugin-apex
-  #         # - https://github.com/salesforcecli/plugin-community
-  #         # - https://github.com/salesforcecli/plugin-custom-metadata
-  #         # - https://github.com/salesforcecli/plugin-data
-  #         # - https://github.com/salesforcecli/plugin-deploy-retrieve
-  #         # - https://github.com/salesforcecli/plugin-dev
-  #         # - https://github.com/salesforcecli/plugin-env
-  #         # - https://github.com/salesforcecli/plugin-info
-  #         # - https://github.com/salesforcecli/plugin-limits
-  #         # - https://github.com/salesforcecli/plugin-login
-  #         # - https://github.com/salesforcecli/plugin-org
-  #         # - https://github.com/salesforcecli/plugin-packaging
-  #         # - https://github.com/salesforcecli/plugin-schema
-  #         # - https://github.com/salesforcecli/plugin-settings
-  #         # - https://github.com/salesforcecli/plugin-signups
-  #         # - https://github.com/salesforcecli/plugin-sobject
-  #         # - https://github.com/salesforcecli/plugin-templates
-  #         - https://github.com/salesforcecli/plugin-user
+  lint-external:
+    uses: ./.github/workflows/externalLint.yml
+    needs: [yarn-lockfile-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        externalProjectGitUrl:
+          # - https://github.com/salesforcecli/plugin-auth
+          # - https://github.com/salesforcecli/plugin-apex
+          # - https://github.com/salesforcecli/plugin-community
+          # - https://github.com/salesforcecli/plugin-custom-metadata
+          # - https://github.com/salesforcecli/plugin-data
+          # - https://github.com/salesforcecli/plugin-deploy-retrieve
+          # - https://github.com/salesforcecli/plugin-dev
+          # - https://github.com/salesforcecli/plugin-env
+          # - https://github.com/salesforcecli/plugin-info
+          # - https://github.com/salesforcecli/plugin-limits
+          # - https://github.com/salesforcecli/plugin-login
+          # - https://github.com/salesforcecli/plugin-org
+          # - https://github.com/salesforcecli/plugin-packaging
+          # - https://github.com/salesforcecli/plugin-schema
+          # - https://github.com/salesforcecli/plugin-settings
+          # - https://github.com/salesforcecli/plugin-signups
+          # - https://github.com/salesforcecli/plugin-sobject
+          # - https://github.com/salesforcecli/plugin-templates
+          - https://github.com/salesforcecli/plugin-user
 
-  #   with:
-  #     packageName: "eslint-config-salesforce-typescript"
-  #     externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
-  #     # preBuildCommands: yarn remove @types/jest
+    with:
+      packageName: "eslint-config-salesforce-typescript"
+      externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
+      # preBuildCommands: yarn remove @types/jest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
           - https://github.com/forcedotcom/source-deploy-retrieve
           - https://github.com/forcedotcom/source-tracking
           - https://github.com/forcedotcom/sfdx-core
+          - https://github.com/forcedotcom/kit
+          - https://github.com/salesforcecli/sf-plugins-core
 
     with:
       packageName: "eslint-config-salesforce-typescript"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: tests
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  yarn-lockfile-check:
+    uses: salesforcecli/github-workflows/.github/workflows/lockFileCheck.yml@main
+
+  lint-external:
+    uses: ./.github/workflows/externalLint.yml
+    needs: [yarn-lockfile-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        externalProjectGitUrl:
+          # - https://github.com/salesforcecli/plugin-auth
+          # - https://github.com/salesforcecli/plugin-apex
+          # - https://github.com/salesforcecli/plugin-community
+          # - https://github.com/salesforcecli/plugin-custom-metadata
+          # - https://github.com/salesforcecli/plugin-data
+          # - https://github.com/salesforcecli/plugin-deploy-retrieve
+          # - https://github.com/salesforcecli/plugin-dev
+          # - https://github.com/salesforcecli/plugin-env
+          # - https://github.com/salesforcecli/plugin-info
+          # - https://github.com/salesforcecli/plugin-limits
+          # - https://github.com/salesforcecli/plugin-login
+          # - https://github.com/salesforcecli/plugin-org
+          # - https://github.com/salesforcecli/plugin-packaging
+          # - https://github.com/salesforcecli/plugin-schema
+          # - https://github.com/salesforcecli/plugin-settings
+          # - https://github.com/salesforcecli/plugin-signups
+          # - https://github.com/salesforcecli/plugin-sobject
+          # - https://github.com/salesforcecli/plugin-templates
+          - https://github.com/salesforcecli/plugin-user
+
+    with:
+      packageName: "eslint-config-salesforce-typescript"
+      externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
+      # preBuildCommands: yarn remove @types/jest


### PR DESCRIPTION
remove the property foo without using `delete` or mutating the original object

```
const {foo, ...objWithoutFoo} = objectWithFoo;
```

foo is unused, and this prevents warnings about it being unused.
This could lead to unintentionally unused destructured props

---

add a LOT of external linting checks (report which repos with fail with the proposed rule change)
sfdx-core is a known failure case as it's not on our current linter standards yet.