### PR TITLE
feat: numeric separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,30 +3,36 @@ module.exports = {
     es6: true,
   },
   extends: [
-    'eslint-config-salesforce',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'eslint-config-prettier',
+    "eslint-config-salesforce",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "eslint-config-prettier",
   ],
-  parser: '@typescript-eslint/parser',
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     project: [
-      './packages/**/tsconfig.json',
-      './packages/**/test/tsconfig.json',
-      './tsconfig.json',
-      './test/tsconfig.json',
+      "./packages/**/tsconfig.json",
+      "./packages/**/test/tsconfig.json",
+      "./tsconfig.json",
+      "./test/tsconfig.json",
     ],
-    sourceType: 'module',
+    sourceType: "module",
   },
-  plugins: ['@typescript-eslint', 'eslint-plugin-import', 'eslint-plugin-jsdoc', 'unicorn'],
+  plugins: [
+    "@typescript-eslint",
+    "eslint-plugin-import",
+    "eslint-plugin-jsdoc",
+    "unicorn",
+  ],
   rules: {
-    'unicorn/prefer-node-protocol': 'error',
+    "unicorn/prefer-node-protocol": "error",
+    "unicorn/numeric-separators-style": "warn",
     // Override @typescript-eslint/recommended
-    '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-namespace': 'off',
-    '@typescript-eslint/restrict-template-expressions': [
-      'error',
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
       {
         allowNullish: true,
         allowBoolean: true,
@@ -35,56 +41,56 @@ module.exports = {
     ],
 
     // Custom @typescript-eslint
-    '@typescript-eslint/array-type': [
-      'error',
+    "@typescript-eslint/array-type": [
+      "error",
       {
-        default: 'array-simple',
+        default: "array-simple",
       },
     ],
-    '@typescript-eslint/consistent-type-assertions': 'error',
-    '@typescript-eslint/explicit-function-return-type': 'error',
-    '@typescript-eslint/explicit-member-accessibility': [
-      'error',
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
       {
-        accessibility: 'explicit',
+        accessibility: "explicit",
       },
     ],
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
       {
         multiline: {
-          delimiter: 'semi',
+          delimiter: "semi",
           requireLast: true,
         },
         singleline: {
-          delimiter: 'semi',
+          delimiter: "semi",
           requireLast: false,
         },
       },
     ],
-    '@typescript-eslint/member-ordering': 'error',
+    "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-shadow": "error",
-    '@typescript-eslint/return-await': 'error',
+    "@typescript-eslint/return-await": "error",
     // turning off the base rule is recommended by ts-eslint
-    'no-return-await': 'off',
-    '@typescript-eslint/prefer-for-of': 'error',
-    '@typescript-eslint/prefer-function-type': 'error',
-    '@typescript-eslint/prefer-includes': 'error',
-    '@typescript-eslint/prefer-nullish-coalescing': 'error',
-    '@typescript-eslint/prefer-optional-chain': 'error',
-    '@typescript-eslint/prefer-reduce-type-parameter': 'error',
-    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-    '@typescript-eslint/quotes': [
-      'error',
-      'single',
+    "no-return-await": "off",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
       {
         avoidEscape: true,
       },
     ],
-    '@typescript-eslint/switch-exhaustiveness-check': 'error',
-    '@typescript-eslint/type-annotation-spacing': 'error',
-    '@typescript-eslint/unified-signatures': 'error',
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "@typescript-eslint/type-annotation-spacing": "error",
+    "@typescript-eslint/unified-signatures": "error",
     "no-shadow": "off",
   },
-  ignorePatterns: ['*.js'],
+  ignorePatterns: ["*.js"],
 };


### PR DESCRIPTION
readability

```ts
const x = 100000000;
```
becomes

```ts
const x = 100_000_000;
```

this'll produce warnings and be autofixable