### PR TITLE
feat: no null/undefined in template literal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,13 @@ jobs:
   yarn-lockfile-check:
     uses: salesforcecli/github-workflows/.github/workflows/lockFileCheck.yml@main
   linux-unit-tests:
-    needs: yarn-lockfile-check
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+      - run: yarn build
+      - run: yarn test
   lint-external:
     uses: ./.github/workflows/externalLint.yml
     strategy:
@@ -39,5 +44,5 @@ jobs:
           - https://github.com/forcedotcom/source-deploy-retrieve
 
     with:
-      packageName: "eslint-config-salesforce-typescript"
+      packageName: 'eslint-config-salesforce-typescript'
       externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': [
       'error',
       {
+        allowNullish: false,
         allowBoolean: true,
         allowNumber: true,
       },

--- a/index.js
+++ b/index.js
@@ -95,19 +95,17 @@ module.exports = {
   ignorePatterns: ['*.js'],
   overrides: [
     {
-      files: ['src/**'],
-      '@typescript-eslint/restrict-template-expressions': [
-        'error',
-        {
-          allowNullish: false,
-          allowBoolean: true,
-          allowNumber: true,
-        },
-      ],
-    },
-    {
+      // put stricter rules you only want to apply to production code here
       files: ['src/**'],
       rules: {
+        '@typescript-eslint/restrict-template-expressions': [
+          'error',
+          {
+            allowNullish: false,
+            allowBoolean: true,
+            allowNumber: true,
+          },
+        ],
         'import/no-extraneous-dependencies': [
           'error',
           {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': [
       'error',
       {
-        allowNullish: false,
+        // true generally (so we get it in /test), we override it to false for src lower down
+        allowNullish: true,
         allowBoolean: true,
         allowNumber: true,
       },
@@ -93,6 +94,17 @@ module.exports = {
   },
   ignorePatterns: ['*.js'],
   overrides: [
+    {
+      files: ['src/**'],
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+          allowNullish: false,
+          allowBoolean: true,
+          allowNumber: true,
+        },
+      ],
+    },
     {
       files: ['src/**'],
       rules: {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': [
       'error',
       {
-        allowNullish: true,
         allowBoolean: true,
         allowNumber: true,
       },


### PR DESCRIPTION
shipping `undefined` and `null` in template literals is bad.  ex:
https://github.com/oclif/plugin-update/pull/855

wouldn't you like the compiler to tell you when you're exposing us to that?

[@W-16115298@](https://gus.lightning.force.com/a07EE00001vTM5cYAG)

to run green, this requires
https://github.com/salesforcecli/plugin-apex/pull/506
https://github.com/forcedotcom/source-tracking/pull/622
https://github.com/salesforcecli/plugin-info/pull/789
https://github.com/salesforcecli/plugin-custom-metadata/pull/868
https://github.com/salesforcecli/plugin-dev/pull/516
https://github.com/salesforcecli/plugin-deploy-retrieve/pull/1093